### PR TITLE
n8vem-mark4: add support for console on PropIO v2 board.

### DIFF
--- a/Kernel/platform-n8vem-mark4/config.h
+++ b/Kernel/platform-n8vem-mark4/config.h
@@ -32,16 +32,9 @@
 #define SWAPTOP	    0xFF00	/* can we stop at the top? not sure how. let's stop short. */
 #define MAX_SWAPS	10	    /* Well, that depends really, hmmmmmm. Pick a number, any number. */
 
-#define BOOT_TTY (512 + 1)/* Set this to default device for stdio, stderr */
-                          /* In this case, the default is the first TTY device */
-
 /* We need a tidier way to do this from the loader */
 #define CMDLINE	(0x0081)  /* Location of root dev name */
 
-/* Device parameters */
-#define NUM_DEV_TTY 2
-
-#define TTYDEV   BOOT_TTY /* Device used by kernel for messages, panics */
 //#define SWAPDEV  (256 + 1)  /* Device for swapping. (z80pack drive J) */
 #define NBUFS    10       /* Number of block buffers */
 #define NMOUNTS	 4	  /* Number of mounts at a time */
@@ -63,3 +56,22 @@
 /* We have a DS1302, we can read the time of day from it */
 #define CONFIG_RTC
 #define CONFIG_RTC_INTERVAL 30 /* deciseconds between reading RTC seconds counter */
+
+/* We have a PropIOv2 board */
+#define CONFIG_PROPIO2
+#define PROPIO2_IO_BASE		0xA8
+
+/* Device parameters */
+#ifdef CONFIG_PROPIO2
+	#define NUM_DEV_TTY 3
+
+	/* PropIO as the console */
+	#define BOOT_TTY (512 + 3)
+#else
+	#define NUM_DEV_TTY 2
+
+	/* ANSI0 as the console */
+	#define BOOT_TTY (512 + 1)
+#endif
+
+#define TTYDEV   BOOT_TTY /* Device used by kernel for messages, panics */

--- a/Kernel/platform-n8vem-mark4/devtty.h
+++ b/Kernel/platform-n8vem-mark4/devtty.h
@@ -4,4 +4,8 @@ void tty_putc(uint8_t minor, unsigned char c);
 bool tty_writeready(uint8_t minor);
 void tty_pollirq_asci0(void);
 void tty_pollirq_asci1(void);
+
+#ifdef CONFIG_PROPIO2
+void tty_poll_propio2(void);
+#endif
 #endif

--- a/Kernel/platform-n8vem-mark4/main.c
+++ b/Kernel/platform-n8vem-mark4/main.c
@@ -16,6 +16,11 @@ void z180_timer_interrupt(void)
     a = TIME_TMDR0L;
     a = TIME_TCR;
 
+#ifdef CONFIG_PROPIO2
+    /* The PropIO2 does not have an interrupt on keypress. */
+    tty_poll_propio2();
+#endif
+
     timer_interrupt();
 }
 


### PR DESCRIPTION
This adds support for the PropIO v2 board as the console. If you set CONFIG_PROPIO2 in platform-n8vem/config.h, then it automatically adds the PropIO as the third tty and uses it as the BOOT_TTY And TTYDEV. 

This could probably be extended to allow the PropIO to be used with the VT subsystem by sending the appropriate ANSI codes to PROPIO2_TERM for all the vt functions.
